### PR TITLE
[Client] 내가 보낸 메시지는 '나'로 표시

### DIFF
--- a/client/src/components/Message.tsx
+++ b/client/src/components/Message.tsx
@@ -106,6 +106,7 @@ interface MessageProps {
 
 const Message = ({ messageData, handleModal, updateMessage }: MessageProps) => {
   const email = useAppSelector(userEmail);
+  console.log(messageData);
   const { id, User, content, is_update, write_date, isAlarm } = messageData;
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [newContent, setNewContent] = useState<string>(content);
@@ -141,7 +142,13 @@ const Message = ({ messageData, handleModal, updateMessage }: MessageProps) => {
       <MainContent>
         <Title>
           <Name>
-            {User ? (isAlarm ? '' : User.nick_name) : '(삭제된 유저)'}
+            {User
+              ? isAlarm
+                ? ''
+                : User.email === email
+                ? '나'
+                : User.nick_name
+              : '(삭제된 유저)'}
           </Name>
           <Date>{write_date}</Date>
           <Edited>{is_update === 'N' ? '' : '(수정됨)'}</Edited>


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 기능 수정 
- [ ] 의존성, 환경 변수, 빌드 업데이트

### 반영 브랜치
- [ ] feature/my-message -> dev

### 변경 사항
- 이메일을 비교해서 로그인된 유저가 보낸 메시지면 닉네임 대신 '나'로 표시함

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플A